### PR TITLE
create typography component + example

### DIFF
--- a/src/Typography/Styles.ts
+++ b/src/Typography/Styles.ts
@@ -1,0 +1,86 @@
+import { StandardPropertiesHyphen } from "csstype";
+import styled, { DefaultTheme } from "styled-components";
+
+import { lightTheme } from "./Themes";
+import {
+  TypographyVariant,
+  TypographyProps,
+  TypographyTags,
+  TypographyVariants,
+} from "./Types";
+
+const variantTagMap: { [key in TypographyVariants]: TypographyTags } = {
+  displayXL: "h1",
+  displayL: "h2",
+  displayM: "h3",
+  displayS: "h4",
+  pageHeader: "h5",
+  body: "p",
+  label: "p",
+};
+
+export const Variant = (variant: TypographyVariant) =>
+  variant
+    ? Object.keys(variant)
+        .map((key) => `${key}: ${variant[key]};`)
+        .join("")
+    : "";
+export const Italic = "font-style: italic";
+export const Strikethrough = "text-decoration: line-through";
+export const Align = (align: StandardPropertiesHyphen["text-align"]) => `text-align: ${align}`;
+
+export const Truncate = `
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+`;
+
+export const MaxLines = (
+  maxLines: number,
+  lineHeight: TypographyVariant["line-height"]
+) => `
+  -webkit-line-clamp: ${maxLines};
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  max-height: calc(${lineHeight} * ${maxLines}),
+  text-overflow: ellipsis;
+`;
+
+export const TypographyStyles = ({
+  theme,
+  variant = "body",
+  color = "primary",
+  font,
+  italic,
+  align,
+  truncate,
+  maxLines,
+  strikethrough,
+}: TypographyProps & { theme?: DefaultTheme }) => {
+  const _theme = theme ? theme["typography"] || lightTheme : lightTheme;
+  const _font = font || "sans";
+  return `
+    margin: 0;
+    padding: 0;
+    color: ${_theme["color"][color]};
+    ${Variant(_theme[_font][variant])};
+    ${italic ? Italic : ""};
+    ${align ? Align(align) : ""};
+    ${strikethrough ? Strikethrough : ""};
+    ${truncate ? Truncate : ""};
+    ${
+      maxLines && maxLines > 0
+        ? MaxLines(maxLines, _theme[_font][variant]["lineHeight"])
+        : ""
+    };   
+  `;
+};
+
+export const Typography = styled.p.attrs<TypographyProps>(
+  ({ as, variant = "body" }) => ({
+    as: as || variantTagMap[variant],
+  })
+)<TypographyProps>`
+  ${(props) => TypographyStyles(props)}
+`;

--- a/src/Typography/Themes.ts
+++ b/src/Typography/Themes.ts
@@ -1,0 +1,68 @@
+import { Color, TypographyTheme, TypographyVariant } from "./Types";
+
+const variantGenerator = (
+  fontFamily: TypographyVariant["font-family"],
+  fontWeight: TypographyVariant["font-weight"],
+  fontSize: TypographyVariant["font-size"],
+  lineHeight: TypographyVariant["line-height"],
+  letterSpacing: TypographyVariant["letter-spacing"]
+) => {
+  return {
+    "font-family": fontFamily,
+    "font-weight": fontWeight,
+    "font-size": fontSize,
+    "line-height": lineHeight,
+    "letter-spacing": letterSpacing,
+  };
+};
+
+const serif = "georgia, serif";
+const sans = "Helvetica, sans-serif";
+const light: {
+  [key in Color]: string;
+} = {
+  primary: "#333",
+  secondary: "#757575",
+  tertiary: "#FFF",
+  error: "#B50303"
+}
+
+const dark: {
+  [key in Color]: string;
+} = {
+  primary: "#FFF",
+  secondary: "#757575",
+  tertiary: "#333",
+  error: "#B50303"
+}
+
+const fonts = {
+  serif: {
+    displayXL: variantGenerator(serif, 200, "52px", "64px", "0"),
+    displayL: variantGenerator(serif, 200, "38px", "50px", "0"),
+    displayM: variantGenerator(serif, 200, "30px", "38px", "0"),
+    displayS: variantGenerator(serif, 200, "22px", "32px", "0"),
+    pageHeader: variantGenerator(serif, 200, "18px", "26px", "0"),
+    body: variantGenerator(serif, 200, "14px", "20px", "0"),
+    label: variantGenerator(serif, 200, "12px", "16px", "0"),
+  },
+  sans: {
+    displayXL: variantGenerator(sans, 700, "52px", "64px", "0.15px"),
+    displayL: variantGenerator(sans, 700, "38px", "50px", "0.15px"),
+    displayM: variantGenerator(sans, 400, "30px", "38px", "0.15px"),
+    displayS: variantGenerator(sans, 400, "22px", "32px", "0.15px"),
+    pageHeader: variantGenerator(sans, 400, "18px", "26px", "0.15px"),
+    body: variantGenerator(sans, 200, "14px", "20px", "0.15px"),
+    label: variantGenerator(sans, 200, "12px", "16px", "0.15px"),
+  },
+};
+
+export const lightTheme: TypographyTheme = {
+  ...fonts,
+  color: light
+}
+
+export const darkTheme: TypographyTheme = {
+  ...fonts,
+  color: dark
+}

--- a/src/Typography/Types.ts
+++ b/src/Typography/Types.ts
@@ -1,0 +1,49 @@
+import { StandardPropertiesHyphen } from "csstype";
+
+export type TypographyVariants =
+  | "displayXL"
+  | "displayL"
+  | "displayM"
+  | "displayS"
+  | "pageHeader"
+  | "body"
+  | "label";
+
+export type TypographyTags = "h1" | "h2" | "h3" | "h4" | "h5" | "p" | "span" | "label";
+export type Font = "serif" | "sans";
+export type Color = "primary" | "secondary" | "tertiary" | "error";
+export type TypographyVariant = Pick<
+  StandardPropertiesHyphen,
+  "font-family" | "font-size" | "font-weight" | "letter-spacing" | "line-height"
+>;
+export type TypographyTheme = {
+  [key in Font]: {
+    [key in TypographyVariants]: TypographyVariant;
+  };
+} & {
+  color: {
+    [key in Color]: string;
+  }
+};
+
+export interface TypographyProps {
+  /** The tag rendered to the dom */
+  as?: TypographyTags;
+  /** The set of base css font styles to be applied to the component */
+  variant?: TypographyVariants;
+  /** Uses a serif font instead of a sansSerif font */
+  font?: Font;
+  /** Sets the font color */
+  color?: Color;
+  /** Sets the text-align css property */
+  align?: StandardPropertiesHyphen["text-align"];
+  /** Sets the text-style css property */
+  italic?: boolean;
+  /** If true and the text is larger than its parent container, the text will truncate using an ellipsis */
+  truncate?: boolean;
+  /** If set, the text will truncate using an ellipsis after a set number of lines of text. */
+  maxLines?: number;
+  /** Sets the text-decoration css property to line-through */
+  strikethrough?: boolean;
+  "data-test-id"?: string;
+}

--- a/src/Typography/index.ts
+++ b/src/Typography/index.ts
@@ -1,0 +1,19 @@
+export {
+  Typography,
+  TypographyStyles,
+  Truncate,
+  MaxLines,
+  Align,
+  Italic,
+  Strikethrough,
+  Variant,
+} from "./Styles";
+export {
+  TypographyVariant,
+  TypographyVariants,
+  TypographyTags,
+  TypographyTheme,
+  Font,
+  TypographyProps,
+} from "./Types";
+export { lightTheme, darkTheme } from "./Themes";

--- a/src/examples/Typography.tsx
+++ b/src/examples/Typography.tsx
@@ -1,0 +1,8 @@
+import * as React from 'react';
+import { Typography } from '../Typography';
+
+export const TypographyExample: React.FC<{}> = () => (
+  <div>
+    <Typography>This is a test</Typography>
+  </div>
+);

--- a/src/forms/Input/styles.ts
+++ b/src/forms/Input/styles.ts
@@ -1,4 +1,4 @@
-import { TextCss } from "forms/TextCss";
+import { TextCss } from "../TextCss";
 import styled, { css } from "styled-components";
 
 export const InputContainer = styled.div`

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,7 +3,9 @@ import { render } from "react-dom";
 import { BrowserRouter as Router, Link, Route, Switch } from "react-router-dom";
 import styled, { ThemeProvider } from "styled-components";
 import { SignupForm } from "./examples/SignupForm";
-import { lightTheme, darkTheme } from "forms/Input";
+import { TypographyExample } from "./examples/Typography";
+import { lightTheme, darkTheme } from "./forms/Input";
+import { lightTheme as typographyLightTheme, darkTheme as typographyDarkTheme } from "./Typography";
 
 const App: React.FC<{}> = () => {
   const [darkMode, setDarkMode] = React.useState(false);
@@ -17,15 +19,19 @@ const App: React.FC<{}> = () => {
               <li>
                 <Link to="/signup">SignupForm</Link>
               </li>
+              <li>
+                <Link to="/typography">Typography</Link>
+              </li>
             </ul>
             <button onClick={() => setDarkMode(!darkMode)}>Toggle theme</button>
           </nav>
 
-          {/* A <Switch> looks through its children <Route>s and
-            renders the first one that matches the current URL. */}
           <Switch>
             <Route path="/signup">
               <SignupForm />
+            </Route>
+            <Route path="/typography">
+              <TypographyExample />
             </Route>
           </Switch>
         </AppContainer>
@@ -46,6 +52,7 @@ const lightModeTheme = {
     textColor: "#333",
     input: lightTheme,
   },
+  typography: typographyLightTheme
 };
 
 const darkModeTheme = {
@@ -54,6 +61,7 @@ const darkModeTheme = {
     textColor: "#eee",
     input: darkTheme,
   },
+  typography: typographyDarkTheme
 };
 
 render(<App />, document.getElementById("root"));


### PR DESCRIPTION
I built a better version of our Typography component that exists today. Here's what I did:

There is no react component whatsoever (in fact, not even a `.tsx` file added). Instead, Typography is actually just a set of styles that comes from `TypographyStyles` function (which you could always use directly instead. I just created a little two liner styled component that implements the styles logic and adds some really simple guessing as to which dom element you're trying to render which can easily be overridden with the as prop.

I split up a lot of the usual styles that we use into their own consts. If you ever wanted to add truncating to your text somewhere, rather than repeating lines, you could just use ${Truncate}; inside your component. I think some reusable css snippets like these are something we haven't done enough of.

Typography can currently create some fonts that aren't in our type ramp (for instance, a body serif variant), but if we enforce this on the design side I don't see an issue with it.

This component will be able to do everything that our original component can do, although I severely limited the ability to use any color you want. If we want to add colors, you'll need to add them to the theme by purpose, which is easy, but a road block (not sure if that's good or not, but it was the easiest way to add colors to the theme).

I was a little bit concerned that some of the logic around styling could potentially slow things down, but I tested the render speed in our app with the react profiler and found that you can render about 100 Typography components at the cost of about 1 ms of render time.

Take a look at the implementation, and feel free to give tons of criticism!
