### PR TITLE
Simple typography

### DIFF
--- a/src/Typography/Styles.ts
+++ b/src/Typography/Styles.ts
@@ -60,27 +60,36 @@ export const TypographyStyles = ({
   strikethrough,
 }: TypographyProps & { theme?: DefaultTheme }) => {
   const _theme = theme ? theme["typography"] || lightTheme : lightTheme;
+  const _variant = typeof variant === "string" ? variant : variant.mobile;
   const _font = font || "sans";
   return `
     margin: 0;
     padding: 0;
     color: ${_theme["color"][color]};
-    ${Variant(_theme[_font][variant])};
+    ${Variant(_theme[_font][_variant])};
     ${italic ? Italic : ""};
     ${align ? Align(align) : ""};
     ${strikethrough ? Strikethrough : ""};
     ${truncate ? Truncate : ""};
     ${
       maxLines && maxLines > 0
-        ? MaxLines(maxLines, _theme[_font][variant]["lineHeight"])
+        ? MaxLines(maxLines, _theme[_font][_variant]["lineHeight"])
         : ""
     };
+
+    @media only screen and (min-width: 768px) {
+      ${typeof variant === "object" && variant.tablet ? Variant(_theme[_font][variant.tablet]) : ""}
+    }
+
+    @media only screen and (min-width: 1280px) {
+      ${typeof variant === "object" && variant.desktop ? Variant(_theme[_font][variant.desktop]) : ""}
+    }
   `;
 };
 
 export const Typography = styled.p.attrs<TypographyProps>(
   ({ as, variant = "body" }) => ({
-    as: as || variantTagMap[variant],
+    as: as || variantTagMap[typeof variant === "object" ? variant.mobile : variant],
   })
 )<TypographyProps>`
   ${(props) => TypographyStyles(props)}

--- a/src/Typography/Types.ts
+++ b/src/Typography/Types.ts
@@ -9,6 +9,12 @@ export type TypographyVariants =
   | "body"
   | "label";
 
+export type ResponsiveTypographyVariants = {
+  mobile: TypographyVariants;
+  tablet?: TypographyVariants;
+  desktop?: TypographyVariants;
+}
+
 export type TypographyTags = "h1" | "h2" | "h3" | "h4" | "h5" | "p" | "span" | "label";
 export type Font = "serif" | "sans";
 export type Color = "primary" | "secondary" | "tertiary" | "error";
@@ -30,7 +36,7 @@ export interface TypographyProps {
   /** The tag rendered to the dom */
   as?: TypographyTags;
   /** The set of base css font styles to be applied to the component */
-  variant?: TypographyVariants;
+  variant?: TypographyVariants | ResponsiveTypographyVariants;
   /** Uses a serif font instead of a sansSerif font */
   font?: Font;
   /** Sets the font color */

--- a/src/examples/Typography.tsx
+++ b/src/examples/Typography.tsx
@@ -3,6 +3,14 @@ import { Typography } from '../Typography';
 
 export const TypographyExample: React.FC<{}> = () => (
   <div>
-    <Typography>This is a test</Typography>
+    <Typography
+      variant={{
+        mobile: "body",
+        tablet: "pageHeader",
+        desktop: "displayS"
+      }}
+    >
+      This is a test
+    </Typography>
   </div>
 );


### PR DESCRIPTION
Since we agree that responsive typography should be created using variants and not relative units, this is a proposal to allow typography variant to accept a variant prop that is either a variant or an object that contains variants for different viewport sizes, which are styled via media queries.

example:

`<Typography variant={{ mobile: "displayS", tablet: "displayM", desktop: "displayL" }}>`

