### PR TITLE
add media queries to theme

### DIFF
--- a/src/Media2Strings.ts
+++ b/src/Media2Strings.ts
@@ -1,0 +1,21 @@
+export interface IMediaQueries {
+  tabletAndAbove: string;
+  desktopAndAbove: string;
+}
+
+export interface Breakpoints {
+  tablet: number;
+  desktop: number;
+}
+
+export class MediaQueries implements IMediaQueries {
+  constructor(private readonly breakpoints: Breakpoints) {}
+
+  get tabletAndAbove() {
+    return `@media only screen and (min-width: ${this.breakpoints.tablet}px)`
+  }
+
+  get desktopAndAbove() {
+    return `@media only screen and (min-width: ${this.breakpoints.desktop}px)`
+  }
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,4 @@
+import { Breakpoints, MediaQueries } from "Media2Strings";
 import React from "react";
 import { render } from "react-dom";
 import { BrowserRouter as Router, Link, Route, Switch } from "react-router-dom";
@@ -56,6 +57,13 @@ const AppContainer = styled.div`
   background: ${(props) => props.theme.appBackgroundColor};
 `;
 
+const breakpoints: Breakpoints = {
+  tablet: 768,
+  desktop: 1280
+}
+
+const mediaQueries = new MediaQueries(breakpoints);
+
 const lightModeTheme = {
   appBackgroundColor: "#fff",
   form: {
@@ -64,6 +72,7 @@ const lightModeTheme = {
   },
   typography: typographyLightTheme,
   button: buttonLightTheme,
+  mediaQueries,
 };
 
 const darkModeTheme = {
@@ -74,6 +83,7 @@ const darkModeTheme = {
   },
   typography: typographyDarkTheme,
   button: buttonDarkTheme,
+  mediaQueries,
 };
 
 render(<App />, document.getElementById("root"));


### PR DESCRIPTION
Adding Media Queries to theme. I simplified the class from web-ui because if we're doing a mobile first approach I think all we need is `tabletAndAbove` and `desktopAndAbove` queries. Only question I have is how we handle Media Queries when no theme Provider is used, we should likely have a default.