### PR TITLE
Typography updates

### DIFF
--- a/src/Typography/Styles.ts
+++ b/src/Typography/Styles.ts
@@ -66,21 +66,21 @@ export const TypographyStyles = ({
     margin: 0;
     padding: 0;
     color: ${_theme["color"][color]};
-    ${Variant(_theme["font"][_variant])};
+    ${Variant(_theme["fonts"][_variant])};
     ${align ? Align(align) : ""};
     ${truncate ? Truncate : ""};
     ${
       maxLines && maxLines > 0
-        ? MaxLines(maxLines, _theme["font"][_variant]["lineHeight"])
+        ? MaxLines(maxLines, _theme["fonts"][_variant]["lineHeight"])
         : ""
     };
 
     @media only screen and (min-width: 768px) {
-      ${typeof variant === "object" && variant.tablet ? Variant(_theme["font"][variant.tablet]) : ""}
+      ${typeof variant === "object" && variant.tablet ? Variant(_theme["fonts"][variant.tablet]) : ""}
     }
 
     @media only screen and (min-width: 1280px) {
-      ${typeof variant === "object" && variant.desktop ? Variant(_theme["font"][variant.desktop]) : ""}
+      ${typeof variant === "object" && variant.desktop ? Variant(_theme["fonts"][variant.desktop]) : ""}
     }
   `;
 };

--- a/src/Typography/Styles.ts
+++ b/src/Typography/Styles.ts
@@ -10,13 +10,19 @@ import {
 } from "./Types";
 
 const variantTagMap: { [key in TypographyVariants]: TypographyTags } = {
-  displayXL: "h1",
-  displayL: "h2",
-  displayM: "h3",
-  displayS: "h4",
-  pageHeader: "h5",
-  body: "p",
-  label: "p",
+  displayXLSerifRegular: "h1",
+  displayLSerifRegular: "h2",
+  displayMSerifRegular: "h3",
+  displaySSansSemiBold: "h4",
+  displaySSansRegular: "h4",
+  displaySSerifRegular: "h4",
+  pageHeaderSerifRegular: "h4",
+  sectionHeaderSansMedium: "h5",
+  subheadingSansRegular: "h5",
+  subheadingSansMedium: "h5",
+  paragraphSansRegular: "p",
+  paragraphSansMedium: "p",
+  labelSansRegular: "p",
 };
 
 export const Variant = (variant: TypographyVariant) =>
@@ -25,8 +31,6 @@ export const Variant = (variant: TypographyVariant) =>
         .map((key) => `${key}: ${variant[key]};`)
         .join("")
     : "";
-export const Italic = "font-style: italic";
-export const Strikethrough = "text-decoration: line-through";
 export const Align = (align: StandardPropertiesHyphen["text-align"]) =>
   `text-align: ${align}`;
 
@@ -50,39 +54,33 @@ export const MaxLines = (
 
 export const TypographyStyles = ({
   theme,
-  variant = "body",
+  variant = "paragraphSansRegular",
   color = "primary",
-  font,
-  italic,
   align,
   truncate,
   maxLines,
-  strikethrough,
 }: TypographyProps & { theme?: DefaultTheme }) => {
   const _theme = theme ? theme["typography"] || lightTheme : lightTheme;
   const _variant = typeof variant === "string" ? variant : variant.mobile;
-  const _font = font || "sans";
   return `
     margin: 0;
     padding: 0;
     color: ${_theme["color"][color]};
-    ${Variant(_theme[_font][_variant])};
-    ${italic ? Italic : ""};
+    ${Variant(_theme["font"][_variant])};
     ${align ? Align(align) : ""};
-    ${strikethrough ? Strikethrough : ""};
     ${truncate ? Truncate : ""};
     ${
       maxLines && maxLines > 0
-        ? MaxLines(maxLines, _theme[_font][_variant]["lineHeight"])
+        ? MaxLines(maxLines, _theme["font"][_variant]["lineHeight"])
         : ""
     };
 
     @media only screen and (min-width: 768px) {
-      ${typeof variant === "object" && variant.tablet ? Variant(_theme[_font][variant.tablet]) : ""}
+      ${typeof variant === "object" && variant.tablet ? Variant(_theme["font"][variant.tablet]) : ""}
     }
 
     @media only screen and (min-width: 1280px) {
-      ${typeof variant === "object" && variant.desktop ? Variant(_theme[_font][variant.desktop]) : ""}
+      ${typeof variant === "object" && variant.desktop ? Variant(_theme["font"][variant.desktop]) : ""}
     }
   `;
 };

--- a/src/Typography/Themes.ts
+++ b/src/Typography/Themes.ts
@@ -1,6 +1,6 @@
 import { Color, TypographyTheme, TypographyVariant } from "./Types";
 
-const variantGenerator = (
+const generateTypographyVariant = (
   fontFamily: TypographyVariant["font-family"],
   fontWeight: TypographyVariant["font-weight"],
   fontSize: TypographyVariant["font-size"],
@@ -36,33 +36,29 @@ const dark: {
   error: "#B50303",
 };
 
-const fonts = {
-  serif: {
-    displayXL: variantGenerator(serif, 200, "52px", "64px", "0"),
-    displayL: variantGenerator(serif, 200, "38px", "50px", "0"),
-    displayM: variantGenerator(serif, 200, "30px", "38px", "0"),
-    displayS: variantGenerator(serif, 200, "22px", "32px", "0"),
-    pageHeader: variantGenerator(serif, 200, "18px", "26px", "0"),
-    body: variantGenerator(serif, 200, "14px", "20px", "0"),
-    label: variantGenerator(serif, 200, "12px", "16px", "0"),
-  },
-  sans: {
-    displayXL: variantGenerator(sans, 700, "52px", "64px", "0.15px"),
-    displayL: variantGenerator(sans, 700, "38px", "50px", "0.15px"),
-    displayM: variantGenerator(sans, 400, "30px", "38px", "0.15px"),
-    displayS: variantGenerator(sans, 400, "22px", "32px", "0.15px"),
-    pageHeader: variantGenerator(sans, 400, "18px", "26px", "0.15px"),
-    body: variantGenerator(sans, 200, "14px", "20px", "0.15px"),
-    label: variantGenerator(sans, 200, "12px", "16px", "0.15px"),
-  },
+const fonts: TypographyTheme["fonts"] = {
+  displayXLSerifRegular: generateTypographyVariant(serif, 400, "72px", "86px", 0),
+  displayLSerifRegular: generateTypographyVariant(serif, 400, "52px", "64px", 0),
+  displayMSerifRegular: generateTypographyVariant(serif, 400, "38px", "50px", 0),
+  displaySSerifRegular: generateTypographyVariant(serif, 400, "30px", "38px", 0),
+  displaySSansRegular: generateTypographyVariant(sans, 400, "30px", "38px", "0.15px"),
+  displaySSansSemiBold: generateTypographyVariant(sans, 700, "30px", "38px", "0.15px"),
+  pageHeaderSerifRegular: generateTypographyVariant(serif, 400, "22px", "32px", 0),
+  sectionHeaderSansMedium: generateTypographyVariant(sans, 400, "22px", "32px", "0.15px"),
+  subheadingSansMedium: generateTypographyVariant(sans, 500, "18px", "26px", "0.15px"),
+  subheadingSansRegular: generateTypographyVariant(sans, 400, "18px", "26px", "0.15px"),
+  paragraphSansMedium: generateTypographyVariant(sans, 500, "14px", "20px", "0.15px"),
+  paragraphSansRegular: generateTypographyVariant(sans, 400, "14px", "20px", "0.15px"),
+  labelSansRegular: generateTypographyVariant(sans, 400, "12px", "16px", "0.15px"),
+
 };
 
 export const lightTheme: TypographyTheme = {
-  ...fonts,
+  fonts,
   color: light,
 };
 
 export const darkTheme: TypographyTheme = {
-  ...fonts,
+  fonts,
   color: dark,
 };

--- a/src/Typography/Types.ts
+++ b/src/Typography/Types.ts
@@ -1,13 +1,19 @@
 import { StandardPropertiesHyphen } from "csstype";
 
 export type TypographyVariants =
-  | "displayXL"
-  | "displayL"
-  | "displayM"
-  | "displayS"
-  | "pageHeader"
-  | "body"
-  | "label";
+  | "displayXLSerifRegular"
+  | "displayLSerifRegular"
+  | "displayMSerifRegular"
+  | "displaySSerifRegular"
+  | "displaySSansSemiBold"
+  | "displaySSansRegular"
+  | "pageHeaderSerifRegular"
+  | "sectionHeaderSansMedium"
+  | "subheadingSansMedium"
+  | "subheadingSansRegular"
+  | "paragraphSansMedium"
+  | "paragraphSansRegular"
+  | "labelSansRegular";
 
 export type ResponsiveTypographyVariants = {
   mobile: TypographyVariants;
@@ -16,16 +22,15 @@ export type ResponsiveTypographyVariants = {
 }
 
 export type TypographyTags = "h1" | "h2" | "h3" | "h4" | "h5" | "p" | "span" | "label";
-export type Font = "serif" | "sans";
 export type Color = "primary" | "secondary" | "tertiary" | "error";
 export type TypographyVariant = Pick<
   StandardPropertiesHyphen,
   "font-family" | "font-size" | "font-weight" | "letter-spacing" | "line-height"
 >;
 export type TypographyTheme = {
-  [key in Font]: {
+  fonts: {
     [key in TypographyVariants]: TypographyVariant;
-  };
+  }
 } & {
   color: {
     [key in Color]: string;
@@ -37,19 +42,13 @@ export interface TypographyProps {
   as?: TypographyTags;
   /** The set of base css font styles to be applied to the component */
   variant?: TypographyVariants | ResponsiveTypographyVariants;
-  /** Uses a serif font instead of a sansSerif font */
-  font?: Font;
   /** Sets the font color */
   color?: Color;
   /** Sets the text-align css property */
   align?: StandardPropertiesHyphen["text-align"];
-  /** Sets the text-style css property */
-  italic?: boolean;
   /** If true and the text is larger than its parent container, the text will truncate using an ellipsis */
   truncate?: boolean;
   /** If set, the text will truncate using an ellipsis after a set number of lines of text. */
   maxLines?: number;
-  /** Sets the text-decoration css property to line-through */
-  strikethrough?: boolean;
   "data-test-id"?: string;
 }

--- a/src/Typography/Typography.test.tsx
+++ b/src/Typography/Typography.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom/extend-expect";
+import * as React from "react";
+import { Typography } from "./Styles";
+import { ThemeProvider } from "styled-components";
+import { darkModeTheme } from "../theme";
+
+describe("typography", () => {
+  it("renders", () => {
+    render(<Typography>test</Typography>);
+    expect(screen.getByText("test")).toBeInTheDocument();
+  });
+
+  it("applies styles from default theme", () => {
+    render(<Typography variant="displayXLSerifRegular">test</Typography>);
+    expect(screen.getByText("test")).toHaveStyle("font-size: 72px; font-weight: 400; line-height: 86px; letter-spacing: 0; color: #333");
+  });
+
+  it("applies styles from custom theme", () => {
+    render(
+      <ThemeProvider theme={darkModeTheme}>
+        <Typography>
+          test
+        </Typography>
+      </ThemeProvider>
+    );
+    expect(screen.getByText("test")).toHaveStyle("color: #FFF")
+  });
+
+  it("Allows responsive styles for variant", () => {
+    render(<Typography variant={{mobile: "labelSansRegular", tablet: "paragraphSansMedium", desktop: "displayXLSerifRegular"}}>test</Typography>);
+  });
+});

--- a/src/Typography/index.ts
+++ b/src/Typography/index.ts
@@ -4,8 +4,6 @@ export {
   Truncate,
   MaxLines,
   Align,
-  Italic,
-  Strikethrough,
   Variant,
 } from "./Styles";
 export {
@@ -13,7 +11,6 @@ export {
   TypographyVariants,
   TypographyTags,
   TypographyTheme,
-  Font,
   TypographyProps,
 } from "./Types";
 export { lightTheme, darkTheme } from "./Themes";

--- a/src/examples/SignupForm/SignUpFormReactFormHooks.tsx
+++ b/src/examples/SignupForm/SignUpFormReactFormHooks.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
 import { useForm } from "react-hook-form";
 import { Button } from "../../forms/Button";
-import { ErrorText } from "../../forms/ErrorText";
 import { HelperText } from "../../forms/HelperText";
 import { Input } from "../../forms/Input";
 import { Label } from "../../forms/Label";
 import { Spacer } from "../../Spacer";
 import { Container, emailRegex, FormField, FormFields, phoneRegex, ToggleShowPasswordButton } from "./common";
+import { ErrorText } from "forms/ErrorText";
 
 interface ISignupFormInputs {
   first: string,
@@ -38,7 +38,7 @@ export const SignupFormReactFormHooks: React.FC<{}> = () => {
     <Container>
       <FormFields template={formLayoutTemplate}>
         <FormField name="firstName">
-          <Label hasError={!!errors.first?.message}>
+          <Label error={!!errors.first?.message}>
             First Name
             <Input
               {...register('first', { required: "Please Enter a first name" })}
@@ -50,7 +50,7 @@ export const SignupFormReactFormHooks: React.FC<{}> = () => {
           </Label>
         </FormField>
         <FormField name="lastName">
-          <Label hasError={!!errors.last?.message}>
+          <Label error={!!errors.last?.message}>
             Last Name
             <Input
               {...register('last', { required: "Please Enter a last name" })}
@@ -61,7 +61,7 @@ export const SignupFormReactFormHooks: React.FC<{}> = () => {
           </Label>
         </FormField>
         <FormField name="email">
-          <Label hasError={!!errors.email?.message}>
+          <Label error={!!errors.email?.message}>
             Email
             <Input
               {...register('email', { required: true, pattern: { value: emailRegex, message: "Enter a valid email" } })}
@@ -72,7 +72,7 @@ export const SignupFormReactFormHooks: React.FC<{}> = () => {
           </Label>
         </FormField>
         <FormField name="phone">
-          <Label hasError={!!errors.phone?.message}>
+          <Label error={!!errors.phone?.message}>
             Phone
             <Input
               {...register('phone', { required: true, pattern: { value: phoneRegex, message: "Enter a valid phone number "} })}
@@ -83,7 +83,7 @@ export const SignupFormReactFormHooks: React.FC<{}> = () => {
           </Label>
         </FormField>
         <FormField name="password">
-          <Label hasError={!!errors.password?.message}>
+          <Label error={!!errors.password?.message}>
             Password
             <Input
               {...register('password', { required: true, minLength: { value: 4, message: "Password must be more than 4 characters" } })}

--- a/src/examples/SignupForm/SignupForm.tsx
+++ b/src/examples/SignupForm/SignupForm.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Button } from "../../forms/Button";
-import { ErrorText } from "../../forms/ErrorText";
 import { HelperText } from "../../forms/HelperText";
+import { ErrorText } from "../../forms/ErrorText";
 import { Input } from "../../forms/Input";
 import { Label } from "../../forms/Label";
 import { unboxFormEventValue } from "../../forms/unboxFormEventValue";
@@ -44,7 +44,7 @@ export const SignupForm: React.FC<{}> = () => {
           </Label>
         </FormField>
         <FormField name="lastName">
-          <Label hasError={lastInvalid}>
+          <Label error={lastInvalid}>
             Last Name
             <Input
               onChange={unboxFormEventValue(setLast)}

--- a/src/examples/Typography.tsx
+++ b/src/examples/Typography.tsx
@@ -5,9 +5,9 @@ export const TypographyExample: React.FC<{}> = () => (
   <div>
     <Typography
       variant={{
-        mobile: "body",
-        tablet: "pageHeader",
-        desktop: "displayS"
+        mobile: "labelSansRegular",
+        tablet: "paragraphSansMedium",
+        desktop: "displayXLSerifRegular"
       }}
     >
       This is a test

--- a/src/forms/ErrorText.tsx
+++ b/src/forms/ErrorText.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
-import { Typography } from "../Typography";
+import { TypographyProps, TypographyStyles } from "../Typography";
 
-export const ErrorText = styled(Typography).attrs({ variant: 'label' })`
-  color: ${(props) => props.theme.form.input.errorColor};
+export const ErrorText = styled.p<Omit<TypographyProps, "color" | "variant">>`
+  ${props => TypographyStyles({...props, color: "error", variant: "labelSansRegular"})};
 `;

--- a/src/forms/HelperText.tsx
+++ b/src/forms/HelperText.tsx
@@ -1,9 +1,6 @@
 import styled from "styled-components";
+import { TypographyProps, TypographyStyles } from "../Typography";
 
-import { TextCss } from "./TextCss";
-
-export const HelperText = styled.p`
-  ${TextCss}
-  padding: 0;
-  margin: 0;
+export const HelperText = styled.p<Omit<TypographyProps, "color" | "variant"> & {error?: boolean}>`
+  ${({error, ...props}) => TypographyStyles({...props, color: error ? "error" : "primary", variant: "labelSansRegular"})}
 `;

--- a/src/forms/InputV2/Input.tsx
+++ b/src/forms/InputV2/Input.tsx
@@ -4,10 +4,10 @@ import uniqueId from 'lodash/uniqueId';
 import { Spacer } from "../../Spacer";
 import { InputContainer } from "./styles";
 import { InputProps } from "./types";
-import { Typography } from "../../Typography";
 import { Label } from "../Label";
 import { ErrorText } from "../ErrorText";
 import { useCombinedRefs } from "../UseCombinedRefs";
+import { HelperText } from "forms/HelperText";
 
 export const Input = React.forwardRef<HTMLInputElement, InputProps>(({
   error,
@@ -24,7 +24,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(({
 
   return (
     <>
-      {label && <Label hasError={!!error} htmlFor={inputId}>{label}</Label>}
+      {label && <Label error={!!error} htmlFor={inputId}>{label}</Label>}
       <InputContainer
         error={!!error}
         disabled={inputElementProps.disabled}
@@ -36,7 +36,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(({
         <input ref={combinedRef} {...inputElementProps} id={inputId} />
         {suffixNode ?? <Spacer size={16} />}
       </InputContainer>
-      {helper && typeof error !== "string" && <Typography variant="label">{helper}</Typography>}
+      {helper && typeof error !== "string" && <HelperText error={error}>{helper}</HelperText>}
       {typeof error === "string" && <ErrorText>{error}</ErrorText>}
     </>
   );

--- a/src/forms/Label.tsx
+++ b/src/forms/Label.tsx
@@ -1,25 +1,6 @@
-import styled, { css, StyledComponent } from "styled-components";
-import { Typography, TypographyProps } from "../Typography";
+import styled from "styled-components";
+import { TypographyStyles, TypographyProps } from "../Typography";
 
-type LabelProps = {
-  hasError?: boolean;
-};
-
-export const Label = styled(Typography).attrs({ as: "label" })<LabelProps>`
-  ${(props) => {
-    const {
-      hasError,
-      theme: {
-        form: {
-          input: { errorColor, textColor },
-        },
-      },
-    } = props;
-    const labelColor = hasError ? errorColor : textColor;
-    return css`
-      color: ${labelColor};
-    `;
-  }}
-` as StyledComponent<"label", any, TypographyProps & {
-  as: string;
-} & LabelProps, "as">;
+export const Label = styled.label<Omit<TypographyProps, "variant"> & {error?: boolean}>`
+  ${({error, ...props}) => TypographyStyles({...props, color: error ? "error" : "primary"})};
+`;


### PR DESCRIPTION
Updated Typography to create variants that align more closely with the variants defined in figma in our official type ramp. I removed the `serif` prop, there's is no `weight` prop, there are no boolean variants, and I ensured our variant names line up very closely with how they're named in figma. This pattern will make everything much easier to extend.

I'm intentionally suggesting we remove some of the flexibility out of this component. The idea is if you need custom text, you should have to use a `styled-component` to do so. This will make tracking deviations much easier. We had way too many undefined states in our original typography component.

I also added some simple tests (critique this part because I'm not actually 100% sure how much/what to test).

Last thing, I also updated the `HelperText`, `ErrorText`, and `Label` components to use the `TypographyStyles` function rather than extending `Typography` directly. The reason for this is that it actually makes a lot of the auto complete and typescript stuff work better. Typescript doesn't like the `as` prop all that much, so while it's fine to use directly on the `Typography` component, I would suggest just creating some simple extensions for other types of text where certain props are set in the `TypogrpahyStyles` component directly rather than with the `attrs` function.

I want to release something like this in the near future out to the broader front end eng team so let's make sure we align on this. I'll put out a proposal highlighting everything I've done here soon with the intention of implementing and releasing in the next week.